### PR TITLE
Lots of CLOSE_WAIT sockets on python 2.6.5 (Ubuntu 10.04 LTS)

### DIFF
--- a/firewall-auth.py
+++ b/firewall-auth.py
@@ -34,6 +34,7 @@ import logging
 import time
 import atexit
 import socket
+import gc
 
 class FirewallState:
   Start, LoggedIn, End = range(3)
@@ -228,6 +229,7 @@ def keep_alive(url):
     logger.debug(response.read())
   finally:
     conn.close()
+    gc.collect()
 
 def get_credentials(args):
   """


### PR DESCRIPTION
The issue is due to improper handling of sockets by HTTPSConnection (http://bugs.python.org/issue10993), a sane way is to do a garbage collect after closing, but instead of collecting after every connection, I think keep_alive is the best place to do it after every successful keepalive request, the last logout conn need not be garbage collected, since the terminating python process would do it anyway.
